### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ The AsciiThis-Bot was a short-lived bot that was hosted on Reddit.com
 Given a text prompt of 'hello ascii! linktoimage', it would reply with an ASCII representation of that image.
 The idea for this spawned from the similar smaller program in Python that I had created. This bot is written in C#.
 
-##Example
-#####Envoking the bot
+## Example
+#### Envoking the bot
 <img src="http://i.imgur.com/lAKqxex.png">
-#####The image given to the bot
+
+#### The image given to the bot
 <img src="http://i.imgur.com/NHQcHwV.gif">
-#####The image outputted by the bot
+
+#### The image output by the bot
 <img src="http://i.imgur.com/jJk2TTR.png">


### PR DESCRIPTION
Markdown requires a space between the text and the number signs.